### PR TITLE
Draft: initial media kit support

### DIFF
--- a/lib/foundation/configuration.dart
+++ b/lib/foundation/configuration.dart
@@ -35,7 +35,7 @@ class Configuration {
   static Future<void> init() async {
     if (Constants.isDesktop) {
       await initWindowManager();
-      DartVLC.initialize();
+      //DartVLC.initialize();
     }
 
     // Connectivity check stream initialised.

--- a/lib/foundation/configuration.dart
+++ b/lib/foundation/configuration.dart
@@ -35,7 +35,7 @@ class Configuration {
   static Future<void> init() async {
     if (Constants.isDesktop) {
       await initWindowManager();
-      //DartVLC.initialize();
+      DartVLC.initialize();
     }
 
     // Connectivity check stream initialised.

--- a/lib/foundation/constants.dart
+++ b/lib/foundation/constants.dart
@@ -8,6 +8,7 @@ class Constants {
   static const mobileWidth = 800;
   static const primaryColor = Colors.red;
   static final isMobileOrWeb = kIsWeb || Platform.isAndroid || Platform.isIOS;
+  static final isWindows = Platform.isWindows;
   static final isDesktop = !isMobileOrWeb;
 
   static const ytCom = 'https://youtube.com';

--- a/lib/ui/screens/home_page/tabs/downloads_tab.dart
+++ b/lib/ui/screens/home_page/tabs/downloads_tab.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:libadwaita/libadwaita.dart';
 import 'package:lucide_icons/lucide_icons.dart';
-import 'package:open_file/open_file.dart';
+import 'package:open_filex/open_filex.dart';
 import 'package:pstube/data/models/models.dart';
 import 'package:pstube/foundation/extensions/extensions.dart';
 import 'package:pstube/states/download_list/download_list.dart';
@@ -54,7 +54,7 @@ class DownloadItemBuilder extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: item.total != 0 && item.total == item.downloaded
-          ? () => OpenFile.open(item.queryVideo.path + item.queryVideo.name)
+          ? () => OpenFilex.open(item.queryVideo.path + item.queryVideo.name)
           : null,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8),

--- a/lib/ui/screens/video_screen/src/platform_video_player.dart
+++ b/lib/ui/screens/video_screen/src/platform_video_player.dart
@@ -66,6 +66,12 @@ class PlatformVideoPlayer extends StatelessWidget {
                     value.url.toString(),
                   ),
                 ),
+            handw: videoonlyStreams.asMap().map(
+                  (key, value) => MapEntry(
+                    value.width!,
+                    value.height!,
+                  ),
+            ),
           );
         } else {
           return VideoPlayerDesktop(

--- a/lib/ui/screens/video_screen/src/platform_video_player.dart
+++ b/lib/ui/screens/video_screen/src/platform_video_player.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pod_player/pod_player.dart';
 import 'package:pstube/data/models/models.dart';
 import 'package:pstube/foundation/services.dart';
+import 'package:pstube/ui/widgets/video_player_desktop/vid_player_mpv.dart';
 import 'package:pstube/ui/widgets/video_player_desktop/video_player_desktop.dart';
 import 'package:pstube/ui/widgets/video_player_mobile.dart';
 
@@ -39,7 +40,7 @@ class PlatformVideoPlayer extends StatelessWidget {
                 )
                 .toList(),
           )
-        : VideoPlayerDesktop(
+        : VideoPlayerMpv(
             isCinemaMode: isCinemaMode,
             url: videoStreams.last.url.toString(),
             resolutions: videoStreams.asMap().map(

--- a/lib/ui/screens/video_screen/src/platform_video_player.dart
+++ b/lib/ui/screens/video_screen/src/platform_video_player.dart
@@ -34,8 +34,8 @@ class PlatformVideoPlayer extends StatelessWidget {
         )
         .toList();
 
-    return Constants.isMobileOrWeb
-        ? VideoPlayerMobile(
+    if (Constants.isMobileOrWeb) {
+        return VideoPlayerMobile(
             defaultQuality: 360,
             resolutions: videoStreams
                 .map(
@@ -49,8 +49,9 @@ class PlatformVideoPlayer extends StatelessWidget {
                   ),
                 )
                 .toList(),
-          )
-        : VideoPlayerMpv(
+          );
+        } else if (Constants.isWindows){ 
+        return VideoPlayerMpv(
             isCinemaMode: isCinemaMode,
             url: videoStreams.last.url.toString(),
             audstreams: audioonlyStreams.asMap().map(
@@ -66,5 +67,17 @@ class PlatformVideoPlayer extends StatelessWidget {
                   ),
                 ),
           );
+        } else {
+          return VideoPlayerDesktop(
+            isCinemaMode: isCinemaMode,
+            url: videoStreams.last.url.toString(),
+            resolutions: videoStreams.asMap().map(
+                  (key, value) => MapEntry(
+                    value.quality!,
+                    value.url.toString(),
+                  ),
+                ),
+          );
+        };
   }
 }

--- a/lib/ui/screens/video_screen/src/platform_video_player.dart
+++ b/lib/ui/screens/video_screen/src/platform_video_player.dart
@@ -23,6 +23,16 @@ class PlatformVideoPlayer extends StatelessWidget {
           (p0) => !(p0.videoOnly ?? false),
         )
         .toList();
+    final videoonlyStreams = videoData.videoStreams!
+        .where(
+          (p0) => !(p0.videoOnly == false),
+        )
+        .toList();
+    final audioonlyStreams = videoData.audioStreams!
+        .where(
+          (p0) => (p0.codec == "opus"), //TODO: make this customizable
+        )
+        .toList();
 
     return Constants.isMobileOrWeb
         ? VideoPlayerMobile(
@@ -43,7 +53,13 @@ class PlatformVideoPlayer extends StatelessWidget {
         : VideoPlayerMpv(
             isCinemaMode: isCinemaMode,
             url: videoStreams.last.url.toString(),
-            resolutions: videoStreams.asMap().map(
+            audstreams: audioonlyStreams.asMap().map(
+                  (key, value) => MapEntry(
+                    value.bitrate!,
+                    value.url.toString(),
+                  ),
+                ),
+            resolutions: videoonlyStreams.asMap().map(
                   (key, value) => MapEntry(
                     value.quality!,
                     value.url.toString(),

--- a/lib/ui/widgets/video_player_desktop/vid_player_mpv.dart
+++ b/lib/ui/widgets/video_player_desktop/vid_player_mpv.dart
@@ -14,12 +14,14 @@ class VideoPlayerMpv extends StatefulWidget {
     required this.audstreams,
     required this.resolutions,
     required this.isCinemaMode,
+    required this.handw,
   });
 
   final ValueNotifier<bool> isCinemaMode;
   final String url;
   final Map<int, String> audstreams;
   final Map<String, String> resolutions;
+  final Map<int, int> handw;
 
   @override
   EventDesktopPlayerState createState() => EventDesktopPlayerState();
@@ -157,10 +159,13 @@ class EventDesktopPlayerState extends State<VideoPlayerMpv> {
   bool _isDownloading = false;
   bool Triggered = false;
   bool isVisible = false;
+  bool Asp = false;
   String? url;
   late List<Media> medias = <Media>[Media(widget.url)];
   late Map<int, String> aud = widget.audstreams;
   late Map<String, String> res = widget.resolutions;
+  late Map<int, int> aspect = widget.handw;
+  late double aspectvalue;
   
 
     void _downloadAction(String vid) async {
@@ -186,6 +191,13 @@ class EventDesktopPlayerState extends State<VideoPlayerMpv> {
 
       setState(() => _isDownloading = false);
       setState(() => Triggered = true);
+      setState(() => Asp = true);
+
+      var aspectlist = aspect.entries.toList();
+      var h = aspectlist[0].key;
+      var w = aspectlist[0].value;
+
+      aspectvalue = h / w;
     }
 
     @override
@@ -201,9 +213,8 @@ class EventDesktopPlayerState extends State<VideoPlayerMpv> {
 
     return Material(
       color: Color.fromARGB(0, 0, 0, 0),
-      child: ConstrainedBox(
-        //TODO: make height customizable, figure out ratio from mpv needs set to proper align with side.
-        constraints: BoxConstraints(maxHeight: 500, maxWidth: 16 / 9 * 500), 
+      child: AspectRatio(
+        aspectRatio: Asp != true ? 5 / 1 : aspectvalue,
         child: Triggered == true
             ? Stack(
               //alignment: Alignment.bottomCenter,

--- a/lib/ui/widgets/video_player_desktop/vid_player_mpv.dart
+++ b/lib/ui/widgets/video_player_desktop/vid_player_mpv.dart
@@ -1,0 +1,240 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_core_video/media_kit_core_video.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:pstube/foundation/extensions/extensions.dart';
+import 'package:pstube/ui/widgets/video_player_desktop/controls_wrapper_desktop.dart';
+import 'package:pstube/ui/widgets/video_player_desktop/states/player_state_provider.dart';
+import 'package:window_manager/window_manager.dart';
+
+class VideoPlayerMpv extends StatefulWidget {
+  const VideoPlayerMpv({
+    super.key,
+    required this.url,
+    required this.resolutions,
+    required this.isCinemaMode,
+  });
+
+  final ValueNotifier<bool> isCinemaMode;
+  final String url;
+  final Map<String, String> resolutions;
+
+  @override
+  EventDesktopPlayerState createState() => EventDesktopPlayerState();
+
+}
+
+//begin seekbar
+class SeekBar extends StatefulWidget {
+  final Player player;
+  const SeekBar({
+    Key? key,
+    required this.player,
+  }) : super(key: key);
+
+  @override
+  State<SeekBar> createState() => _SeekBarState();
+}
+
+class _SeekBarState extends State<SeekBar> {
+  bool isPlaying = false;
+  Duration position = Duration.zero;
+  Duration duration = Duration.zero;
+  double volume = 0.5;
+
+  List<StreamSubscription> subscriptions = [];
+
+  @override
+  void initState() {
+    super.initState();
+    isPlaying = widget.player.state.isPlaying;
+    position = widget.player.state.position;
+    duration = widget.player.state.duration;
+    volume = widget.player.state.volume;
+    
+    subscriptions.addAll(
+      [
+        widget.player.streams.isPlaying.listen((event) {
+          setState(() {
+            isPlaying = event;
+          });
+        }),
+        widget.player.streams.position.listen((event) {
+          setState(() {
+            position = event;
+          });
+        }),
+        widget.player.streams.duration.listen((event) {
+          setState(() {
+            duration = event;
+          });
+        }),
+        widget.player.streams.volume.listen((event) {
+          setState(() {
+            volume = event;
+          });
+        }),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    for (final s in subscriptions) {
+      s.cancel();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          IconButton(
+            onPressed: widget.player.playOrPause,
+            icon: Icon(
+              isPlaying ? Icons.pause : Icons.play_arrow,
+            ),
+            color: Theme.of(context).toggleableActiveColor,
+            iconSize: 36.0,
+          ),
+          Text(position.toString().substring(2, 7)),
+          Expanded(
+            child: Slider(
+              min: 0.0,
+              max: duration.inMilliseconds.toDouble(),
+              value: position.inMilliseconds.toDouble().clamp(
+                    0,
+                    duration.inMilliseconds.toDouble(),
+                  ),
+              onChanged: (e) {
+                setState(() {
+                  position = Duration(milliseconds: e ~/ 1);
+                });
+              },
+              onChangeEnd: (e) {
+                widget.player.seek(Duration(milliseconds: e ~/ 1));
+              },
+            ),
+          ),
+          //Text(duration.toString().substring(2, 7)),
+          //IconButton(
+          //  onPressed: ,
+          //  icon: Icon(
+          //    volume = 0.0 ? Icons.volume_off : Icons.volume_up,
+          //  ),
+          //  color: Theme.of(context).primaryColor,
+          //  iconSize: 36.0,
+          //),
+        ],
+      )
+      
+    );
+  }
+}
+//end seekbar
+
+class EventDesktopPlayerState extends State<VideoPlayerMpv> {
+
+      // Create a [Player] instance from `package:media_kit`.
+  final Player player = Player();
+  // Reference to the [VideoController] instance from `package:media_kit_core_video`.
+  VideoController? controller;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      controller = await VideoController.create(player.handle);
+      setState(() {});
+    });
+  }
+
+  bool _isDownloading = false;
+  bool Triggered = false;
+  bool isVisible = false;
+  String? url;
+  late List<Media> medias = <Media>[Media(widget.url)];
+  
+
+    void _downloadAction() async {
+      
+      await player.open(Playlist(medias));
+
+      setState(() => _isDownloading = false);
+      setState(() => Triggered = true);
+    }
+
+    @override
+  void dispose() {
+    Future.microtask(() async {
+      await controller?.dispose();
+      await player.dispose();
+    });;
+    super.dispose();
+  }
+    @override
+  Widget build(BuildContext context) {
+
+    return Material(
+      color: Color.fromARGB(0, 0, 0, 0),
+      child: ConstrainedBox(
+        //TODO: make height customizable, figure out ratio from mpv needs set to proper align with side.
+        constraints: BoxConstraints(maxHeight: 300, maxWidth: 16 / 9 * 300), 
+        child: Triggered == true
+            ? Stack(
+              //alignment: Alignment.bottomCenter,
+              children: [
+                  Center(child: Video(controller: controller)),
+                  if(isVisible)
+                  Container(
+                    child: Align(
+                    alignment: Alignment.bottomRight,
+                    child: Container(
+                      color: Color.fromARGB(125, 0, 0, 0),
+                      child: SeekBar(player: player),
+                    )
+                  )
+                ),
+                MouseRegion(
+                  onEnter: (PointerEvent details)=>setState(()=>isVisible = true),
+                  onExit: (PointerEvent details)=>setState(()=>isVisible = false),
+                  opaque: false,
+                )
+              ]
+            )
+            : //Stack(
+                //children: [
+                  Center(
+                    child: OutlinedButton.icon(
+                      style: OutlinedButton.styleFrom(
+                        backgroundColor: Theme.of(context).colorScheme.surface,
+                      ),
+                      icon: _isDownloading
+                          ? const SizedBox(
+                              width: 24,
+                              height: 24,
+                              child: CircularProgressIndicator.adaptive(
+                                  strokeWidth: 2),
+                            )
+                          : const Icon(Icons.download_outlined),
+                        label: Text("test"),
+                      onPressed: _downloadAction,
+                    ),
+                  )
+                //],
+              ),
+      );
+
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -618,16 +618,20 @@ packages:
   media_kit:
     dependency: "direct main"
     description:
-      path: "../media_kit/media_kit"
-      relative: true
-    source: path
+      path: media_kit
+      ref: HEAD
+      resolved-ref: d49b9b06c92b3be553ee9d2699d99496313a6458
+      url: "https://github.com/alexmercerind/media_kit/"
+    source: git
     version: "0.0.1"
   media_kit_core_video:
     dependency: "direct main"
     description:
-      path: "../media_kit/media_kit_core_video"
-      relative: true
-    source: path
+      path: media_kit_core_video
+      ref: HEAD
+      resolved-ref: d49b9b06c92b3be553ee9d2699d99496313a6458
+      url: "https://github.com/alexmercerind/media_kit/"
+    source: git
     version: "0.0.1"
   meta:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.5"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   audio_video_progress_bar:
     dependency: "direct main"
     description:
@@ -55,7 +55,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "7d14b53fa17058d9d6ba414e7f55aa36ec19846d"
+      resolved-ref: bb7a4a0ae265c32dc4b59288357592aabdc6baa9
       url: "https://github.com/MMMzq/bot_toast.git"
     source: git
     version: "4.0.3"
@@ -72,7 +72,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
@@ -100,7 +100,7 @@ packages:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.7"
   built_collection:
     dependency: "direct main"
     description:
@@ -114,28 +114,28 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.4.1"
+    version: "8.4.2"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.3"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   characters:
     dependency: transitive
     description:
@@ -156,7 +156,7 @@ packages:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   cli_util:
     dependency: transitive
     description:
@@ -177,7 +177,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
@@ -212,7 +212,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   cookie_jar:
     dependency: transitive
     description:
@@ -247,7 +247,7 @@ packages:
       name: custom_text
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0-dev.3"
+    version: "0.6.0"
   dart_style:
     dependency: transitive
     description:
@@ -275,7 +275,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.8"
   dio:
     dependency: "direct main"
     description:
@@ -364,7 +364,7 @@ packages:
       name: flutter_html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0-alpha.5"
+    version: "3.0.0-alpha.6"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -383,7 +383,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-dev.9"
+    version: "2.1.3"
   flutter_staggered_grid_view:
     dependency: "direct main"
     description:
@@ -397,7 +397,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.6"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -409,7 +409,7 @@ packages:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -437,21 +437,21 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   gsettings:
     dependency: transitive
     description:
       name: gsettings
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.7"
   hive:
     dependency: "direct main"
     description:
@@ -479,14 +479,14 @@ packages:
       name: hooks_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-dev.9"
+    version: "2.1.3"
   html:
     dependency: "direct main"
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   http:
     dependency: transitive
     description:
@@ -507,14 +507,14 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   image:
     dependency: transitive
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.0"
   intl:
     dependency: "direct main"
     description:
@@ -542,7 +542,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   libadwaita:
     dependency: "direct main"
     description:
@@ -586,14 +586,14 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   lottie:
     dependency: transitive
     description:
       name: lottie
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.3"
   lucide_icons:
     dependency: "direct main"
     description:
@@ -607,7 +607,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
@@ -615,6 +615,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.5"
+  media_kit:
+    dependency: "direct main"
+    description:
+      path: "../media_kit/media_kit"
+      relative: true
+    source: path
+    version: "0.0.1"
+  media_kit_core_video:
+    dependency: "direct main"
+    description:
+      path: "../media_kit/media_kit_core_video"
+      relative: true
+    source: path
+    version: "0.0.1"
   meta:
     dependency: transitive
     description:
@@ -628,7 +642,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   msix:
     dependency: "direct dev"
     description:
@@ -649,7 +663,7 @@ packages:
       name: numerus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.0"
   octo_image:
     dependency: transitive
     description:
@@ -671,15 +685,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
-  open_file:
+  open_filex:
     dependency: "direct main"
     description:
-      path: "."
-      ref: no_system
-      resolved-ref: e404897e55f7b595ac8af1ee3e2eceb74d790de9
-      url: "https://github.com/miDeb/open_file.git"
-    source: git
-    version: "3.2.1"
+      name: open_filex
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.2"
   package_config:
     dependency: transitive
     description:
@@ -721,7 +733,7 @@ packages:
       name: package_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   package_info_plus_windows:
     dependency: transitive
     description:
@@ -770,7 +782,7 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.19"
+    version: "2.0.22"
   path_provider_ios:
     dependency: transitive
     description:
@@ -798,7 +810,7 @@ packages:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   path_provider_windows:
     dependency: transitive
     description:
@@ -819,42 +831,42 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.0.0"
+    version: "10.2.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.0.0"
+    version: "10.2.0"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.4"
+    version: "9.0.7"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.7.0"
+    version: "3.9.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   piped_api:
     dependency: "direct main"
     description:
@@ -877,7 +889,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   pod_player:
     dependency: "direct main"
     description:
@@ -885,6 +897,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.6.2"
   pool:
     dependency: transitive
     description:
@@ -912,7 +931,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
@@ -947,21 +966,28 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-dev.9"
+    version: "2.1.3"
   rxdart:
     dependency: transitive
     description:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.5"
+    version: "0.27.7"
+  safe_local_storage:
+    dependency: transitive
+    description:
+      name: safe_local_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   screen_retriever:
     dependency: transitive
     description:
       name: screen_retriever
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.5"
   share_plus:
     dependency: "direct main"
     description:
@@ -989,7 +1015,7 @@ packages:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.14"
   shared_preferences_ios:
     dependency: transitive
     description:
@@ -1003,7 +1029,7 @@ packages:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -1017,7 +1043,7 @@ packages:
       name: shared_preferences_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -1031,21 +1057,21 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1078,21 +1104,21 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3+1"
+    version: "2.2.2"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1+1"
+    version: "2.4.0+2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   state_notifier:
     dependency: transitive
     description:
@@ -1113,28 +1139,28 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0+2"
+    version: "3.0.0+3"
   term_glyph:
     dependency: transitive
     description:
@@ -1148,7 +1174,7 @@ packages:
       name: text_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "0.4.1"
   timeago:
     dependency: "direct main"
     description:
@@ -1184,20 +1210,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.4"
+  uri_parser:
+    dependency: transitive
+    description:
+      name: uri_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.7"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.17"
+    version: "6.0.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1246,7 +1279,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
@@ -1260,42 +1293,42 @@ packages:
       name: very_good_analysis
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   video_player:
     dependency: transitive
     description:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.10"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.9"
+    version: "2.3.10"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.5"
+    version: "2.3.8"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.4"
+    version: "6.0.1"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.13"
   wakelock:
     dependency: transitive
     description:
@@ -1337,7 +1370,7 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1358,14 +1391,14 @@ packages:
       name: window_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.9"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   xml:
     dependency: transitive
     description:
@@ -1386,7 +1419,7 @@ packages:
       name: youtube_explode_dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.3"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,10 @@ dependencies:
   dart_vlc: ^0.4.0
     # git:
     #   url: https://github.com/alexmercerind/dart_vlc
+  media_kit:
+    path: "../media_kit/media_kit"
+  media_kit_core_video:
+    path: "../media_kit/media_kit_core_video"
   dio: ^4.0.4
   dio_cookie_manager: ^2.0.0
   equatable: ^2.0.3 
@@ -43,10 +47,7 @@ dependencies:
   libadwaita_searchbar_ac: ^0.5.8
   libadwaita_window_manager: ^0.5.4
   lucide_icons: ^0.104.0
-  open_file: # Upgrade to pub.dev when package > 3.2.1
-    git:
-      url: https://github.com/miDeb/open_file.git
-      ref: no_system
+  open_filex: ^4.3.0
   package_info_plus: ^1.3.0
   page_transition: ^2.0.5
   path: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,9 +21,15 @@ dependencies:
     # git:
     #   url: https://github.com/alexmercerind/dart_vlc
   media_kit:
-    path: "../media_kit/media_kit"
+    git:
+      url: https://github.com/alexmercerind/media_kit/
+      path: media_kit
+    #path: "../media_kit/media_kit"
   media_kit_core_video:
-    path: "../media_kit/media_kit_core_video"
+    git:
+      url: https://github.com/alexmercerind/media_kit/
+      path: media_kit_core_video
+    #path: "../media_kit/media_kit_core_video"
   dio: ^4.0.4
   dio_cookie_manager: ^2.0.0
   equatable: ^2.0.3 
@@ -65,7 +71,7 @@ dependencies:
   timeago: ^3.2.1
   url_launcher: ^6.0.18
   window_manager: ^0.2.6
-  youtube_explode_dart: ^1.12.0
+  youtube_explode_dart: ^1.12.3
 
 dev_dependencies:
   build_runner: ^2.1.11

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <dart_vlc/dart_vlc_plugin.h>
+#include <media_kit_core_video/media_kit_core_video_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -19,6 +20,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   DartVlcPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DartVlcPlugin"));
+  MediaKitCoreVideoPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("MediaKitCoreVideoPluginCApi"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenRetrieverPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
   dart_vlc
+  media_kit_core_video
   permission_handler_windows
   screen_retriever
   share_plus


### PR DESCRIPTION
Very WIP support for media_kit, based on the new https://github.com/alexmercerind/media_kit which can be thought of the successor to dart_vlc, it already out preforms dart_vlc for high resolution content as well as supporting hwdecode. currently can load a video and play it back using a very basic taskbar. good enough for testing. 

not sure when I'll have the time to finish this up and clean it up, but media_kit support for Linux and OSX is still lacking anyways and I assume those are major blockers in any case.
 

- [x]  Windows support
- [x] Support for Split streaming (1080p+ resolution)
- [ ] Linux support
- [ ] OSX support
- [ ] Better control system
- [ ] stability